### PR TITLE
Add stat and read without length functionality.

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Ceph-Rados version 0.02
 =======================
 
 This module provides a very limited subset of the librados API,
-currently just read/writes and lists.
+currently just read/write/stat and lists.
 
 INSTALLATION
 

--- a/XS/IO.xs
+++ b/XS/IO.xs
@@ -64,8 +64,24 @@ _append(io, oid, data, len)
   OUTPUT:
     RETVAL
 
+void
+_stat(io, oid)
+    rados_ioctx_t    io
+    const char *     oid
+  PREINIT:
+    size_t           size;
+    time_t           mtime;
+    int              err;
+  PPCODE:
+    err = rados_stat(io, oid, &size, &mtime);
+    if (err < 0)
+        croak("cannot stat object '%s': %s", oid, strerror(-err));
+    XPUSHs(sv_2mortal(newSVuv(size)));
+    XPUSHs(sv_2mortal(newSVuv(mtime)));
+
+
 SV *
-read(io, oid, len, off = 0)
+_read(io, oid, len, off = 0)
     rados_ioctx_t    io
     const char *     oid
     size_t           len

--- a/lib/Ceph/Rados.pm
+++ b/lib/Ceph/Rados.pm
@@ -82,6 +82,7 @@ Ceph::Rados - Perl wrapper to librados.
   my $io = $cluster->io('testing_pool');
   $io->write('greeting', 'hello');
   my $stored_data = $io->read('greeting',10);
+  my ($len, $mtime) = $io->stat('greeting');
   $io->delete('greeting');
 
   my $list = $io->list;
@@ -92,9 +93,10 @@ Ceph::Rados - Perl wrapper to librados.
 =head1 DESCRIPTION
 
 This module provides a very limited subset of the librados API,
-currently just read/writes and lists.
+currently just read/write/stat and lists.
 
-read also requires length.
+If no length is passed to the read() call, the object is first stat'd
+to determine the correct read length.
 
 =head1 SEE ALSO
 

--- a/lib/Ceph/Rados/IO.pm
+++ b/lib/Ceph/Rados/IO.pm
@@ -40,6 +40,21 @@ sub append {
     $self->_append($oid, $data, length($data));
 }
 
+sub read {
+    my ($self, $oid, $len, $off) = @_;
+    # if undefined is passed as len, we stat the obj first to get the correct len
+    if (!defined($len)) {
+        ($len, undef) = $self->_stat($oid);
+    }
+    $off ||= 0;
+    $self->_read($oid, $len, $off);
+}
+
+sub stat {
+    my ($self, $oid) = @_;
+    $self->_stat($oid);
+}
+
 # Autoload methods go after =cut, and are processed by the autosplit program.
 
 1;

--- a/t/100_raw_api_crud.t
+++ b/t/100_raw_api_crud.t
@@ -1,6 +1,6 @@
 use strictures;
 
-use Test::More tests => 14;
+use Test::More tests => 18;
 use Test::Exception;
 use Ceph::Rados;
 use Data::Dump qw/dump/;
@@ -26,6 +26,10 @@ SKIP: {
     my $length = length($content);
     ok( my $stored_data = $io->read($filename, $length), "Read $length bytes from object" );
     is( $stored_data, $content, "Get back content ok" );
+    ok( my $stored_data2 = $io->read($filename), "Read unknown bytes from object" );
+    is( $stored_data2, $content, "Get back content ok without read size" );
+    ok( my ($stat_size, $stat_mtime) = $io->stat($filename), "Stat object" );
+    is( $stat_size, $length, "Stat size is same as content length" );
     ok( $list = $io->list, "Opened list context" );
     my $match = 0;
     while (my $entry = $list->next) {


### PR DESCRIPTION
This pull request adds stat'ing functionality, which allows us to do reading without knowing the length (if the length is not passed, we will stat the object first to determine it's length.) 

If you do not pass the length, it will take longer to return since we are stat'ing the object to determine it's length. 

Feel free to cleanup or modify.