### PR TITLE
Adds support for getting the required alignment

### DIFF
--- a/XS/IO.xs
+++ b/XS/IO.xs
@@ -101,6 +101,18 @@ _read(io, oid, len, off = 0)
     RETVAL
 
 int
+_pool_required_alignment(io)
+    rados_ioctx_t    io
+  PREINIT:
+    const char *     buf;
+    int              res;
+  CODE:
+    res = rados_ioctx_pool_required_alignment(io);
+    RETVAL = res;
+  OUTPUT:
+    RETVAL
+
+int
 remove(io, oid)
     rados_ioctx_t    io
     const char *     oid

--- a/lib/Ceph/Rados/IO.pm
+++ b/lib/Ceph/Rados/IO.pm
@@ -71,6 +71,11 @@ sub stat {
     $self->_stat($oid);
 }
 
+sub pool_required_alignment {
+    my ($self) = @_;
+    return $self->_pool_required_alignment();
+}
+
 sub mtime {
     my ($self, $oid) = @_;
     my (undef, $mtime) = $self->_stat($oid);


### PR DESCRIPTION
This adds the method `pool_required_alignment` which will return an erasure coded pools stripe width alignment.
